### PR TITLE
Changes to accept NPerf fixtures targeting generic types.

### DIFF
--- a/src/NPerf.Experiment/AssemblyLoader.cs
+++ b/src/NPerf.Experiment/AssemblyLoader.cs
@@ -48,6 +48,42 @@
             }
 
             return instance;
-        }        
+        }
+
+        /// <summary>
+        /// This method is needed to create an instance of a generic type using the
+        /// fully qualified name.
+        /// <see cref="http://msdn.microsoft.com/en-us/library/w3f99sx1.aspx"/>
+        /// </summary>
+        /// <param name="assemblyName">The name of the assembly</param>
+        /// <param name="typeName">The full name of the type</param>
+        /// <returns>A new instance of the specified type</returns>
+        public static object CreateInstanceFullyQualifiedName(string assemblyName, string typeName)
+        {
+            if (string.IsNullOrWhiteSpace(assemblyName))
+            {
+                throw new ArgumentNullException("assemblyName");
+            }
+
+            if (string.IsNullOrWhiteSpace(typeName))
+            {
+                throw new ArgumentNullException("typeName");
+            }
+
+            var assembly = AssembliesManager.LoadAssembly(assemblyName);
+            var type = Type.GetType(typeName + "," + assembly.FullName);
+
+            var instance = type == null ? null : Activator.CreateInstance(type);
+            if (instance != null)
+            {
+                Console.WriteLine(@"Instance of type {0} was created.", typeName);
+            }
+            else
+            {
+                Console.Error.WriteLine(@"Instance of type {0} was not created.", typeName);
+            }
+
+            return instance;
+        }
     }
 }

--- a/src/NPerf.Experiment/ExperimentScope.cs
+++ b/src/NPerf.Experiment/ExperimentScope.cs
@@ -14,7 +14,7 @@
                 var suite = AssemblyLoader.CreateInstance<PerfTestSuite>(
                     startParameters.SuiteAssembly, startParameters.SuiteType);
 
-                var subject = AssemblyLoader.CreateInstance(
+                var subject = AssemblyLoader.CreateInstanceFullyQualifiedName(
                     startParameters.SubjectAssembly, startParameters.SubjectType);
 
                 var start = startParameters.Start;

--- a/src/NPerf.Lab/ExperimentProcess.cs
+++ b/src/NPerf.Lab/ExperimentProcess.cs
@@ -70,7 +70,7 @@
                     this.testName,
                     testerType.Assembly.Location,
                     this.testedType.Assembly.Location,
-                    this.testedType.Name,
+                    this.testedType.FullName, // Is necesary to load generics to use FullName instead of Name
                     this.ChannelName,
                     start,
                     step,
@@ -92,7 +92,7 @@
                     this.testName,
                     testerType.Assembly.Location,
                     this.testedType.Assembly.Location,
-                    this.testedType.Name,
+                    this.testedType.FullName, // Is necesary to load generics to use FullName instead of Name
                     this.ChannelName);
             
             this.Run(waitForExit);

--- a/src/NPerf.Lab/PerfLab.cs
+++ b/src/NPerf.Lab/PerfLab.cs
@@ -90,9 +90,15 @@
         private static bool IsTestableType(Type testerType, Type testedType)
         {
             var testerAttr = testerType.Attribute<PerfTesterAttribute>();
-            return testedType.IsPublic && !testedType.IsGenericTypeDefinition
-                   && testerAttr.TestedType.IsAssignableFrom(testedType) && !(testerAttr.TestedType == testedType)
-                   && !testedType.IsAbstract && !testedType.IsInterface;
+            var commonConditions = testedType.IsPublic && !(testerAttr.TestedType == testedType)
+                                   && !testedType.IsAbstract && !testedType.IsInterface;
+            var isTestableNonGeneric = !testedType.IsGenericTypeDefinition
+                   && testerAttr.TestedType.IsAssignableFrom(testedType);
+            var isTestableGeneric = testedType.IsGenericType && testerAttr.TestedType.IsGenericType &&
+                testedType.GetInterfaces().Any(x => x.IsGenericType &&
+                    x.GetGenericTypeDefinition() == testerAttr.TestedType.GetGenericTypeDefinition());
+
+            return commonConditions && (isTestableGeneric || isTestableNonGeneric);
         }
 
         public SystemInfo SystemInfo { get; private set; }


### PR DESCRIPTION
I made the necessary changes to allow NPerf framework fixtures to target generic types (IList<int> for example) and I tested them with NPerf.Fixture.ISorter (non-generic) and NPerf.Fixture.IList (generic).
